### PR TITLE
Update CascadingConfigServiceProvider.php

### DIFF
--- a/src/CascadingConfigServiceProvider.php
+++ b/src/CascadingConfigServiceProvider.php
@@ -24,7 +24,7 @@ class CascadingConfigServiceProvider extends ServiceProvider {
      */
     public function register()
     {
-        $envConfigPath = config_path() . '/../config.' . env('APP_ENV');
+        $envConfigPath = config_path() . '/../config/' . env('APP_ENV');
 
         if (!file_exists($envConfigPath) || !is_dir($envConfigPath)) {
             // Nothing to do here


### PR DESCRIPTION
Change `.` to `/` so that you can use the same cascading setup as previously and not need to dirty your root directory with `config.{env}` folders.
