### PR TITLE
Two improvements to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,8 +66,8 @@ config.local
 
 ## Usage
 
-1. Fill the configuration into your environment-based config directory (`config.local`, `config.staging`, `config.production`), just like what you've always done in Laravel 4
-1. Call `config($key)` just like what you've always done in Laravel 5
+1. Fill the configuration into your environment-based config directory (`config.local`, `config.staging`, `config.production`), just like you've always done in Laravel 4
+1. Call `config($key)` just like you've always done in Laravel 5
 
 ## Notes
 

--- a/README.md
+++ b/README.md
@@ -64,6 +64,12 @@ config.local
     └── app.php
 ```
 
+Finally, you may need to re-cache your config:
+
+``` bash
+php artisan config:cache
+```
+
 ## Usage
 
 1. Fill the configuration into your environment-based config directory (`config.local`, `config.staging`, `config.production`), just like you've always done in Laravel 4


### PR DESCRIPTION
I've two minor improvements to the docs:
- A grammar fix
- A reminder that if the configuration is cached, the changes won't take effect until this is regenerated. I'm new to Laravel, so I don't know if this is obvious to the seasoned user, but I imagine something like this - with wording adjusted if necessary - might be useful?

Happy to hear amendment suggestions before merging down.

Thanks for your work on this - I'd not used L4, but not having a per-env config system seems very odd to say the least!
