### PR TITLE
Fix config caching

### DIFF
--- a/src/CascadingConfigServiceProvider.php
+++ b/src/CascadingConfigServiceProvider.php
@@ -24,6 +24,11 @@ class CascadingConfigServiceProvider extends ServiceProvider
      */
     public function register()
     {
+        if (file_exists($this->app->getCachedConfigPath())) {
+            // Config is cached, no need to load it again
+            return;
+        }
+
         $env = $this->app->environment();
 
         $envConfigPath = (new SysSplFileInfo(dirname($this->getConfigPath())."/config.$env"))->getRealPath();


### PR DESCRIPTION
If the config is cached (`artisan config:cache`) then `LoadConfiguration.php` will load the cached config so no need to load it again.
